### PR TITLE
Add scdaemon to desktops

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -42,6 +42,8 @@ class ocf_desktop::packages {
     ['libnotify-bin', 'notification-daemon']:;
     # performance improvements
     ['preload']:;
+    # security tools
+    ['scdaemon']:;
     # Xorg
     ['xserver-xorg', 'xclip', 'xscreensaver']:;
   }


### PR DESCRIPTION
scdaemon allows for `gpg --edit-card` and other tools to query smart cards for information. (Useful for e.g. the yubikey and other hardware 2FA).

I'm not the most familiar with puppet to so let me know if I'm being an idiot.